### PR TITLE
Revise Join of Play_By_Play to PBP_Participation

### DIFF
--- a/nfl_data_py/__init__.py
+++ b/nfl_data_py/__init__.py
@@ -145,7 +145,10 @@ def import_pbp_data(
                 if all([include_participation, year >= 2016, not cache]):
                     path = r'https://github.com/nflverse/nflverse-data/releases/download/pbp_participation/pbp_participation_{}.parquet'.format(year)
                     partic = pandas.read_parquet(path)
-                    raw = raw.merge(partic, how='left', on=['play_id','old_game_id'])
+                    raw = raw.merge(partic,
+                                    how='left',
+                                    left_on=['play_id','game_id'],
+                                    right_on=['play_id','nflverse_game_id'])
                 
                 pbp_data.append(raw)
                 print(str(year) + ' done.')


### PR DESCRIPTION
Resolves issue with play_by_play data having incorrect old_game_id values. For example, all old_game_id values in the play_by_play_2023 for week 15 start with "2022" but they begin with "2023" in the pbp_participation_2023 data.