### PR TITLE
Update import_weekly_rosters method in __init__.py

### DIFF
--- a/nfl_data_py/__init__.py
+++ b/nfl_data_py/__init__.py
@@ -471,7 +471,8 @@ def import_weekly_rosters(years, columns=None):
             how="left"
         ).gameday
     )
-    rosters["age"] = ((roster_dates - rosters.birth_date).dt.days / 365.25).round(3)
+    if "age" in columns:
+        rosters["age"] = ((roster_dates - rosters.birth_date).dt.days / 365.25).round(3)
     
     return rosters
     

--- a/nfl_data_py/__init__.py
+++ b/nfl_data_py/__init__.py
@@ -471,7 +471,7 @@ def import_weekly_rosters(years, columns=None):
             how="left"
         ).gameday
     )
-    if "age" in columns:
+    if columns is not None and "age" in columns:
         rosters["age"] = ((roster_dates - rosters.birth_date).dt.days / 365.25).round(3)
     
     return rosters


### PR DESCRIPTION
Update import_weekly_rosters to check if "age" column was specified by user before computing it for return. NOTE: this will additionally provide a workaround for https://github.com/cooperdff/nfl_data_py/issues/75 for users that do not require "age" in the output, given that column's computation is causing the errors described in that issue.