### PR TITLE
Release v1.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,6 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+# Mac local files
+.DS_Store

--- a/nfl_data_py/__init__.py
+++ b/nfl_data_py/__init__.py
@@ -150,7 +150,7 @@ def import_pbp_data(
                 pbp_data.append(raw)
                 print(str(year) + ' done.')
 
-            except Error as e:
+            except Exception as e:
                 print(e)
                 print('Data not available for ' + str(year))
     
@@ -1138,18 +1138,6 @@ def clean_nfl_data(df):
         'Southern Miss': 'Southern Mississippi',
         'Louisiana State': 'LSU'
     }
-
-    pro_tm_repl = {
-        'GNB': 'GB',
-        'KAN': 'KC',
-        'LA': 'LAR',
-        'LVR': 'LV',
-        'NWE': 'NE',
-        'NOR': 'NO',
-        'SDG': 'SD',
-        'SFO': 'SF',
-        'TAM': 'TB'
-    }
     
     na_replace = {
         'NA':numpy.nan
@@ -1163,9 +1151,5 @@ def clean_nfl_data(df):
 
     if 'col_team' in df.columns:
         df.replace({'col_team': col_tm_repl}, inplace=True)
-
-        if 'name' in df.columns:
-            for z in player_col_tm_repl:
-                df[df['name'] == z[0]] = df[df['name'] == z[0]].replace({z[1]: z[2]})
 
     return df

--- a/nfl_data_py/tests/nfl_test.py
+++ b/nfl_data_py/tests/nfl_test.py
@@ -1,6 +1,7 @@
 from unittest import TestCase
 from pathlib import Path
 import shutil
+import random
 
 import pandas as pd
 
@@ -20,7 +21,7 @@ class test_pbp(TestCase):
 		
         
     def test_uses_cache_when_cache_is_true(self):
-        cache = Path(__file__).parent/"tmpcache"
+        cache = Path(__file__).parent/f"tmpcache-{random.randint(0, 10000)}"
         self.assertRaises(
             ValueError,
             nfl.import_pbp_data, [2020], cache=True, alt_path=cache
@@ -268,17 +269,14 @@ class test_ftn(TestCase):
         
 class test_cache(TestCase):
     def test_cache(self):
-        cache = Path(__file__).parent/"tmpcache"
+        cache = Path(__file__).parent/f"tmpcache-{random.randint(0, 10000)}"
         self.assertFalse(cache.is_dir())
         
         nfl.cache_pbp([2020], alt_path=cache)
         
-        new_paths = list(cache.glob("**/*"))
-        self.assertEqual(len(new_paths), 2)
-        self.assertTrue(new_paths[0].is_dir())
-        self.assertTrue(new_paths[1].is_file())
-        
-        pbp2020 = pd.read_parquet(new_paths[1])
+        self.assertTrue(cache.is_dir())
+
+        pbp2020 = pd.read_parquet(cache/"season=2020"/"part.0.parquet")
         self.assertIsInstance(pbp2020, pd.DataFrame)
         self.assertFalse(pbp2020.empty)
         

--- a/setup.py
+++ b/setup.py
@@ -14,22 +14,23 @@ from setuptools import find_packages, setup, Command
 # Package meta-data.
 NAME = 'nfl_data_py'
 DESCRIPTION = 'python library for interacting with NFL data sourced from nflfastR'
-URL = 'https://github.com/cooperdff/nfl_data_py'
-EMAIL = 'cooper.dff11@gmail.com'
-AUTHOR = 'cooperdff'
-REQUIRES_PYTHON = '>=3.6.0'
+URL = 'https://github.com/nflverse/nfl_data_py'
+EMAIL = 'alec.ostrander@gmail.com'
+AUTHOR = 'Alec Ostrander'
+REQUIRES_PYTHON = '>=3.9.0'
 VERSION = '0.3.1'
 
 
 # What packages are required for this module to be executed?
 REQUIRED = [
-    'pandas>1',
+    'pandas>=2',
+    'numpy=>=2'
     'appdirs>1',
-    'fastparquet>0.5',
 ]
 
 # What packages are optional?
 EXTRAS = {
+    "fastparquet": ['fastparquet>0.5']
 }
 
 # The rest you shouldn't have to touch too much :)


### PR DESCRIPTION
nfl_data_py 1.0.0 will feature a number of fixes to get the library up to speed and ready to serve nflverse users for the 2024 season!

Breaking Changes:
-

We are removing support for some old dependencies to reduce unnecessary maintenance complexity. If your app currently requires one of these older versions, please upgrade prior to using nfl_data_py >= 1.0.0.

Minimum versions:
- Python 3.6 -> 3.9+ ([migration guide](https://goatswitch.ai/python-3-12-migration-guide-master-the-upgrade-from-python-3-8/))
- numpy 1.0 -> 2.0+ ([migration guide](https://numpy.org/doc/stable/numpy_2_0_migration_guide.html))
- pandas 1.0 -> 2.0+ ([migration guide](https://www.datacamp.com/blog/pandas-2-what-is-new-and-top-tips))

Enhancements:
-

- TBD

Bug Fixes:
-

- TBD