### PR TITLE
fix initial retrieval of data with import_pbp_data

### DIFF
--- a/nfl_data_py/__init__.py
+++ b/nfl_data_py/__init__.py
@@ -7,6 +7,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import appdirs
 import numpy
+numpy.float_=numpy.float64
 import pandas
 from typing import Iterable
 


### PR DESCRIPTION
This pull request replaces the usage of `numpy.float_` with `numpy.float64` in the `__init__.py` file to prevent potential compatibility issues. The `numpy.float_` has been deprecated in some environments, leading to warnings or errors.

Issue #95 
